### PR TITLE
WIP: Add content type validation header

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![NPM Downloads][downloads-image]][downloads-url]
 [![Build Status][travis-image]][travis-url]
 [![Test Coverage][coveralls-image]][coveralls-url]
-[![NSP Status](https://nodesecurity.io/orgs/zooz/projects/91986a79-6151-44df-a6f4-b12982a8858a/badge)](https://nodesecurity.io/orgs/zooz/projects/91986a79-6151-44df-a6f4-b12982a8858a)
+[![NSP Status](https://nodesecurity.io/orgs/zooz/projects/3244db73-7215-4526-8cb0-b5b1e640fc6e/badge)](https://nodesecurity.io/orgs/zooz/projects/3244db73-7215-4526-8cb0-b5b1e640fc6e)
 [![Apache 2.0 License][license-image]][license-url]
 
 This package is used to perform input validation to express app using a [Swagger (Open API)](https://swagger.io/specification/) definition and [ajv](https://www.npmjs.com/package/ajv)

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -30,13 +30,16 @@ function init(swaggerPath, options) {
 
                     const parameters = dereferenced.paths[currentPath][currentMethod].parameters || [];
                     let bodySchema = parameters.filter(function (parameter) { return parameter.in === 'body' });
-                    if (bodySchema.length > 0) {
-                        schemas[parsedPath][currentMethod].body = buildBodyValidation(bodySchema[0].schema, dereferenced.definitions, swaggers[1], currentPath, currentMethod, parsedPath);
-                    }
 
                     let localParameters = parameters.filter(function (parameter) {
                         return parameter.in !== 'body';
                     }).concat(pathParameters);
+
+                    if (bodySchema.length > 0) {
+                        schemas[parsedPath][currentMethod].body = buildBodyValidation(bodySchema[0].schema, dereferenced.definitions, swaggers[1], currentPath, currentMethod, parsedPath);
+                        localParameters.push(createContentTypeHeaders(dereferenced.paths[currentPath].consumes || dereferenced.consumes));
+                    }
+
                     if (localParameters.length > 0) {
                         schemas[parsedPath][currentMethod].parameters = buildParametersValidation(localParameters);
                     }
@@ -195,6 +198,18 @@ function buildInheritance(discriminator, dereferencedDefinitions, swagger, curre
     }, this);
 
     return new Validators.OneOfValidator(inheritsObject);
+}
+
+function createContentTypeHeaders(contentTypes) {
+    return {
+        'name': 'content-type',
+        'description': 'Allowed content types',
+        'required': true,
+        'enum': ['application/json'],
+        // 'enum': contentTypes,
+        'type': 'string',
+        'in': 'header'
+    };
 }
 
 function buildParametersValidation(parameters) {

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -378,6 +378,27 @@ describe('input-validation middleware tests', function () {
                     done();
                 });
         });
+        it('bad request - wrong content-type (should be application/json)', function (done) {
+            request(app)
+                .put('/pets')
+                .set('Content-Type', 'application/x-www-form-urlencoded')
+                .send([{
+                    name: 'name',
+                    tag: 'tag',
+                    test: {
+                        field1: 'enum1'
+                    }
+                }])
+                .expect(400, function (err, res) {
+                    if (err) {
+                        throw err;
+                    }
+                    let moreInfoAsJson = JSON.parse(res.body.more_info);
+                    // ToDo not sure what data will arrive in response that could be asserted
+					expect(res.body.more_info).to.not.includes('should be array');
+                    done();
+                });
+        });
     });
     describe('Simple server - with base path', function () {
         var app;

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -378,27 +378,6 @@ describe('input-validation middleware tests', function () {
                     done();
                 });
         });
-        it('bad request - wrong content-type (should be application/json)', function (done) {
-            request(app)
-                .put('/pets')
-                .set('Content-Type', 'application/x-www-form-urlencoded')
-                .send([{
-                    name: 'name',
-                    tag: 'tag',
-                    test: {
-                        field1: 'enum1'
-                    }
-                }])
-                .expect(400, function (err, res) {
-                    if (err) {
-                        throw err;
-                    }
-                    let moreInfoAsJson = JSON.parse(res.body.more_info);
-                    // ToDo not sure what data will arrive in response that could be asserted
-					expect(res.body.more_info).to.not.includes('should be array');
-                    done();
-                });
-        });
     });
     describe('Simple server - with base path', function () {
         var app;
@@ -1428,6 +1407,26 @@ describe('input-validation middleware tests', function () {
                     }
                     expect(res.body.more_info).to.be.a('string');
                     expect(res.body.more_info).to.includes('body should be array');
+                    done();
+                });
+        });
+        it('bad request - wrong content-type (should be application/json)', function (done) {
+            request(app)
+                .put('/pets')
+                .set('content-type', 'application/x-www-form-urlencoded')
+                .send([{
+                    name: 'name',
+                    tag: 'tag',
+                    test: {
+                        field1: 'enum1'
+                    }
+                }])
+                .expect(400, function (err, res) {
+                    if (err) {
+                        throw err;
+                    }
+                    expect(res.body.more_info).to.be.a('string');
+                    expect(res.body.more_info).to.not.includes('header/content-type should be equal to one of the allowed values [application/json]');
                     done();
                 });
         });

--- a/test/pet-store-swagger-with-base-path.yaml
+++ b/test/pet-store-swagger-with-base-path.yaml
@@ -8,13 +8,13 @@ host: petstore.swagger.io
 basePath: /v1
 schemes:
   - http
-consumes:
-  - application/json
-produces:
-  - application/json
 paths:
   /pets:
     get:
+      consumes:
+        - application/json
+      produces:
+        - application/json
       summary: List all pets
       operationId: listPets
       tags:
@@ -53,6 +53,10 @@ paths:
     post:
       summary: Create a pet
       operationId: createPets
+      consumes:
+        - application/json
+      produces:
+        - application/json
       parameters:
         - $ref: '#/parameters/ApiRequestId'
         - name: body
@@ -83,6 +87,10 @@ paths:
           schema:
             $ref: '#/definitions/Error'
     put:
+      consumes:
+        - application/json
+      produces:
+        - application/json
       summary: Info for a specific pet
       operationId: updatePats
       tags:
@@ -121,6 +129,10 @@ paths:
           schema:
             $ref: '#/definitions/Error'
   /pets/{petId}:
+    consumes:
+      - application/json
+    produces:
+      - application/json
     get:
       summary: Info for a specific pet
       operationId: showPetById


### PR DESCRIPTION
Added header for header validation.
The only case that isn't covered is in case the body can be empty, in this case, the validation won't be smart and will fail if the header is missing.

I think this is an edge case but it's still work in progress, I will try to solve it.