### PR TITLE
adding a check for requestBody on current path and method

### DIFF
--- a/src/swagger3/open-api3.js
+++ b/src/swagger3/open-api3.js
@@ -10,6 +10,9 @@ module.exports = {
 };
 
 function buildBodyValidation(dereferenced, originalSwagger, currentPath, currentMethod, middlewareOptions = {}) {
+    if (!dereferenced.paths[currentPath][currentMethod].requestBody){
+        return;
+    }
     const bodySchemaV3 = dereferenced.paths[currentPath][currentMethod].requestBody.content['application/json'].schema;
     const defaultAjvOptions = {
         allErrors: true

--- a/test/openapi3/openapi3-test.js
+++ b/test/openapi3/openapi3-test.js
@@ -26,6 +26,17 @@ describe('input-validation middleware tests', function () {
                 app = testServer;
             });
         });
+        it('valid pets', function (done) {
+            request(app)
+                .get('/pets')
+                .expect(200, function (err, res) {
+                    if (err) {
+                        throw err;
+                    }
+                    expect(res.body.result).to.equal('OK');
+                    done();
+                });
+        });
         it('valid dog', function (done) {
             request(app)
                 .post('/pet')

--- a/test/openapi3/pets.yaml
+++ b/test/openapi3/pets.yaml
@@ -23,6 +23,60 @@ security:
   - app-id: []
     private-key: []
 paths:
+  /pets:
+    get:
+      summary: get all pets
+      security:
+      - public-key: []
+      description: >-
+      tags:
+      - pets
+      operationId: listPets
+      responses:
+        '200':
+          description: list of pets
+          headers:
+            x-zooz-request-id:
+              description: request id
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/pets'
+        '400':
+          description: Bad request
+          headers:
+            x-zooz-request-id:
+              description: request id
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_model'
+        '401':
+          description: Unauthorize
+          headers:
+            x-zooz-request-id:
+              description: request id
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_model'
+        '500':
+          description: Internal error
+          headers:
+            x-zooz-request-id:
+              description: request id
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_model'
   /pet:
     post:
       summary: Create a Pet
@@ -368,6 +422,10 @@ components:
       oneOf:
         - $ref: '#/components/schemas/dog_object'
         - $ref: '#/components/schemas/cat_object'
+    pets:
+      type: array
+      items:
+        $ref: "#/components/schemas/pet"
     pet-discriminator-on-child:
       description: pet
       type: object

--- a/test/openapi3/test-server-pet.js
+++ b/test/openapi3/test-server-pet.js
@@ -20,6 +20,9 @@ module.exports = function (options) {
             var app = express();
             app.use(bodyParser.json());
 
+            app.get('/pets', inputValidation.validate, function (req, res, next) {
+                res.json({ result: 'OK' });
+            });
             app.post('/pet', inputValidation.validate, function (req, res, next) {
                 res.json({ result: 'OK' });
             });


### PR DESCRIPTION
making sure the current path and method have a requestBody before extracting its schema, avoiding an empty requestBody for GET requests