### PR TITLE
docs(README): add Snyk badge to test for vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![NPM Downloads][downloads-image]][downloads-url]
 [![Build Status][travis-image]][travis-url]
 [![Test Coverage][coveralls-image]][coveralls-url]
-[![NSP Status](https://nodesecurity.io/orgs/zooz/projects/3244db73-7215-4526-8cb0-b5b1e640fc6e/badge)](https://nodesecurity.io/orgs/zooz/projects/3244db73-7215-4526-8cb0-b5b1e640fc6e)
+[![Known Vulnerabilities][snyk-image]][snyk-url]
 [![Apache 2.0 License][license-image]][license-url]
 
 This package is used to perform input validation to express app using a [Swagger (Open API)](https://swagger.io/specification/) definition and [ajv](https://www.npmjs.com/package/ajv)
@@ -179,3 +179,5 @@ npm test
 [downloads-url]: https://npmjs.org/package/express-ajv-swagger-validation
 [license-image]: https://img.shields.io/badge/license-Apache_2.0-green.svg?style=flat
 [license-url]: LICENSE
+[snyk-image]: https://snyk.io/test/npm/express-ajv-swagger-validation/badge.svg
+[snyk-url]: https://snyk.io/test/npm/express-ajv-swagger-validation


### PR DESCRIPTION
I replaced nsp (out of date badge), with Snyk to show the known vulnerabilities status for the project.
Would be great to see the project adds a GitHub integration too with Snyk to make sure no new changes are introducing security risks and newly disclosed vulnerabilities for dependencies used here will be monitored :-)