### PR TITLE
docs(license): update to match LICENSE file

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "homepage": "https://github.com/Zooz/express-ajv-swagger-validation",
   "author": "Idan Tovi",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "dependencies": {
     "ajv": "^6.6.2",
     "clone-deep": "^4.0.1",


### PR DESCRIPTION
Seems that license in package manifest and the LICENSE file differ.
I suspect the correct is the LICENSE file so I updated the manifest to match