### PR TITLE
docs(readme): cleaned up badges that don't render

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
 # express-ajv-swagger-validation
-[![NPM](https://nodei.co/npm/express-ajv-swagger-validation.png)](https://nodei.co/npm/express-ajv-swagger-validation/)
-
-[![NPM](https://nodei.co/npm-dl/express-ajv-swagger-validation.png?height=3)](https://nodei.co/npm/express-ajv-swagger-validation/)
 
 [![Join the chat at https://gitter.im/Zooz/express-ajv-swagger-validation](https://badges.gitter.im/Zooz/express-ajv-swagger-validation.svg)](https://gitter.im/Zooz/express-ajv-swagger-validation?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![NPM Version][npm-image]][npm-url]


### PR DESCRIPTION
These two README badges show:
1. 'npm install <package>'
2. download counts

We cover both of these through the README with other instructions and badges so they seem less relevant, and at the moment they anyway don't render due to SSL certificate issues in the nodei.co domain

We can add them back at a later time when the issues resolve