### PR TITLE
Remove snyk protection

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,8 +1,0 @@
-# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.13.5
-ignore: {}
-# patches apply the minimum changes required to fix a vulnerability
-patch:
-  SNYK-JS-LODASH-450202:
-    - api-schema-builder > json-schema-deref-sync > lodash:
-        patched: '2019-07-04T04:52:25.335Z'

--- a/package.json
+++ b/package.json
@@ -32,9 +32,7 @@
     "test": "nyc node_modules/mocha/bin/_mocha --recursive ./test/*/*/*-test.js ./test/*/*-test.js ./test/*-test.js && npm run lint:types",
     "node6-test": "nyc node_modules/mocha/bin/_mocha --recursive ./test/express/*/*-test.js ./test/express/*-test.js ./test/*-test.js",
     "coveralls": "cat ./coverage/lcov.info | ./node_modules/.bin/coveralls",
-    "doctoc": "npm install -g doctoc && doctoc README.md",
-    "snyk-protect": "snyk protect",
-    "prepublish": "npm run snyk-protect"
+    "doctoc": "npm install -g doctoc && doctoc README.md"
   },
   "repository": {
     "type": "git",
@@ -59,8 +57,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "api-schema-builder": "^1.0.9",
-    "memoizee": "^0.4.14",
-    "snyk": "^1.189.0"
+    "memoizee": "^0.4.14"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^1.9.0",
@@ -96,6 +93,5 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
-  },
-  "snyk": true
+  }
 }


### PR DESCRIPTION
This is no longer needed, npm automatically resolves safe packages based on specified version ranges, since updated `lodash` and `json-schema-deref-sync` are available.