### PR TITLE
accept RegExp as type of format.pattern

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -35,7 +35,7 @@ export enum frameworks {
 
 export interface format {
     name: string;
-    pattern: string;
+    pattern: RegExp | string;
 }
 
 export interface ajvValidatorOptions {


### PR DESCRIPTION
Thank you for creating nice lib!
I found a type checking error when specifying format by RegExp such as written in README. This PR will fix it.