### PR TITLE
Fix incorrect type of InputValidationError

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -19,7 +19,7 @@ export { validate };
 export class InputValidationError extends Error {
     errors: Array<ErrorDetails | string>;
 
-    constructor(errors: Array<ErrorDetails>, path?: string, method?: string, options?: inputValidationOptions)
+    constructor(errors: Array<ErrorDetails>, options?: inputValidationOptions)
 }
 
 export interface ErrorDetails {


### PR DESCRIPTION
The constructor only takes `errors` and `options`.