### PR TITLE
Update api-schema-builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -340,12 +340,13 @@
       "dev": true
     },
     "api-schema-builder": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/api-schema-builder/-/api-schema-builder-1.1.6.tgz",
-      "integrity": "sha512-2XUhHmT428Y/r2zbpiGb5Tcxo7GmVb/CW6DYTGw4Fdh1I9unkLvuNlNi5VqqcmpG6QbJvpFO7DfMNDGRPTeNXQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/api-schema-builder/-/api-schema-builder-1.2.0.tgz",
+      "integrity": "sha512-UM/CZ97KKo7JjYzT4Zq9eS8jLrbx8ux1tHjabm78KR68LAzILCckjKwxCkn2zxla36bq+cYgmHUa4G9aUW569A==",
       "requires": {
         "ajv": "^6.10.2",
         "clone-deep": "^4.0.1",
+        "decimal.js": "^10.2.0",
         "js-yaml": "^3.13.1",
         "json-schema-deref-sync": "^0.10.1",
         "object.values": "^1.1.0",
@@ -1098,6 +1099,11 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
+    },
+    "decimal.js": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.0.tgz",
+      "integrity": "sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw=="
     },
     "deep-eql": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "author": "Idan Tovi",
   "license": "Apache-2.0",
   "dependencies": {
-    "api-schema-builder": "^1.1.6",
+    "api-schema-builder": "^1.2.0",
     "memoizee": "^0.4.14"
   },
   "devDependencies": {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,7 +6,9 @@
  * configuration options. This function should be called
  * before using `validate` middleware.
  */
-export function init(swaggerPath: string, options?: ajvValidatorOptions): void;
+declare function init(schemaPath: string, options?: ajvValidatorOptions): void;
+declare function init(jsonSchema: object, options?: ajvValidatorOptions): void;
+export { init };
 
 /**
  * Middleware that validates the request against the swagger

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,15 +7,15 @@
  * before using `validate` middleware.
  */
 declare function init(schemaPath: string, options?: ajvValidatorOptions): void;
-declare function init(jsonSchema: object, options?: ajvValidatorOptions): void;
+declare function init(jsonSchema: Object, options?: ajvValidatorOptions): void;
 export { init };
 
 /**
  * Middleware that validates the request against the swagger
  * file, according to the request method and route
  */
-declare function validate(ctx: any, next: Function): void; // koa
-declare function validate(req: any, res: any, next: Function): void; // express
+declare function validate(ctx: Object, next: Function): void; // koa
+declare function validate(req: Object, res: Object, next: Function): void; // express
 export { validate };
 
 export class InputValidationError extends Error {


### PR DESCRIPTION
- Support OpenApi formats by default - Closes #88 and closes #70 
- Accept JSON Schema in constructor - Closes #80
- Update types