### PR TITLE
Multiple content type support

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -54,9 +54,13 @@ function _validateRequest(requestOptions) {
 
 function _validateBody(body, path, method, contentType) {
     return new Promise(function (resolve, reject) {
-        const methodSchema = schemaEndpointResolver.getMethodSchema(schemas, path, method);
-        if (methodSchema && methodSchema.body && !(methodSchema.body[contentType] ? methodSchema.body[contentType].validate(body) : methodSchema.body.validate(body))) {
-            return reject(methodSchema.body[contentType] ? methodSchema.body[contentType].errors : methodSchema.body.errors);
+        const methodSchema = schemaEndpointResolver.getMethodSchema(schemas, path, method) || {};
+
+        if (methodSchema.body) {
+            const validator = methodSchema.body[contentType] || methodSchema.body;
+            if (!validator.validate(body)) {
+                return reject(validator.errors);
+            }
         }
         return resolve();
     });

--- a/test/openapi3/openapi3-test.js
+++ b/test/openapi3/openapi3-test.js
@@ -68,6 +68,40 @@ describe('input-validation middleware tests', function () {
                     done();
                 });
         });
+        it('validate depending on content-type -- valid dog', function (done) {
+            request(app)
+                .post('/pet')
+                .set('public-key', '1.0')
+                .set('content-type', 'application/x-www-form-urlencoded')
+                .send({
+                    bark: 'foo'
+                })
+                .expect(200, function (err, res) {
+                    if (err) {
+                        throw err;
+                    }
+                    expect(res.body.result).to.equal('OK');
+                    done();
+                });
+        });
+        it('validate depending on content-type -- invalid dog', function (done) {
+            request(app)
+                .post('/pet')
+                .set('public-key', '1.0')
+                .set('content-type', 'application/x-www-form-urlencoded')
+                .send({
+                    bark: 'not foo'
+                })
+                .expect(400, function (err, res) {
+                    if (err) {
+                        throw err;
+                    }
+                    expect(res.body).to.deep.equal({
+                        'more_info': '["body/bark should be equal to one of the allowed values [foo,bar]","body should have required property \'fur\'","body should match exactly one schema in oneOf"]'
+                    });
+                    done();
+                });
+        });
         it('valid cat', function (done) {
             request(app)
                 .post('/pet')

--- a/test/openapi3/pets.yaml
+++ b/test/openapi3/pets.yaml
@@ -138,6 +138,9 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/pet'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/pet2'
         description: Create pet
         required: true
   /dog/{id}:
@@ -493,6 +496,12 @@ components:
       oneOf:
         - $ref: '#/components/schemas/dog_object'
         - $ref: '#/components/schemas/cat_object'
+    pet2:
+      description: pet
+      type: object
+      oneOf:
+        - $ref: '#/components/schemas/dog_object2'
+        - $ref: '#/components/schemas/cat_object'
     pets:
       type: array
       items:
@@ -549,6 +558,16 @@ components:
       properties:
         bark:
           type: string
+    dog_object2:
+      type: object
+      required:
+        - bark
+      properties:
+        bark:
+          type: string
+          enum:
+            - foo
+            - bar
     dog_multiple:
       type: object
       required:

--- a/test/openapi3/test-server-pet.js
+++ b/test/openapi3/test-server-pet.js
@@ -18,6 +18,7 @@ module.exports = function (options) {
     inputValidation.init(`${__dirname}/pets.yaml`, options || inputValidationOptions);
     const app = express();
     app.use(bodyParser.json());
+    app.use(bodyParser.urlencoded());
 
     app.get('/pets', inputValidation.validate, function (req, res, next) {
         res.json({ result: 'OK' });


### PR DESCRIPTION
In OpenAPI3 you can define the requestBody multiple times for different content-types

This change will make the request validator validate based on the content-type (if defined)

Sorry for closing and reopening this PR. I'd like my fork's master branch to be in a state where I can merge without also updating PRs into your repo.