### PR TITLE
Updated request validation content-type to strip additional info

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -30,9 +30,10 @@ function validate(...args) {
 }
 
 function _validateRequest(requestOptions) {
+    const requestContentType = requestOptions.headers['content-type'] && requestOptions.headers['content-type'].split(';')[0].trim(); // This is to filter out things like charset
     return Promise.all([
         _validateParams(requestOptions.headers, requestOptions.params, requestOptions.query, requestOptions.files, requestOptions.path, requestOptions.method.toLowerCase()).catch(e => e),
-        _validateBody(requestOptions.body, requestOptions.path, requestOptions.method.toLowerCase(), requestOptions.headers['content-type']).catch(e => e)
+        _validateBody(requestOptions.body, requestOptions.path, requestOptions.method.toLowerCase(), requestContentType).catch(e => e)
     ]).then(function (errors) {
         if (errors[0] || errors[1]) {
             return errors[0] && errors[1] ? Promise.reject(errors[0].concat(errors[1])) : errors[0] ? Promise.reject(errors[0]) : Promise.reject(errors[1]);

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -29,11 +29,16 @@ function validate(...args) {
     return framework.validate(_validateRequest, ...args);
 }
 
+function _getContentType(headers) {
+    // This is to filter out things like charset
+    const contentType = headers['content-type'];
+    return contentType && contentType.split(';')[0].trim(); 
+}
+
 function _validateRequest(requestOptions) {
-    const requestContentType = requestOptions.headers['content-type'] && requestOptions.headers['content-type'].split(';')[0].trim(); // This is to filter out things like charset
     return Promise.all([
         _validateParams(requestOptions.headers, requestOptions.params, requestOptions.query, requestOptions.files, requestOptions.path, requestOptions.method.toLowerCase()).catch(e => e),
-        _validateBody(requestOptions.body, requestOptions.path, requestOptions.method.toLowerCase(), requestContentType).catch(e => e)
+        _validateBody(requestOptions.body, requestOptions.path, requestOptions.method.toLowerCase(), _getContentType(requestOptions.headers)).catch(e => e)
     ]).then(function (errors) {
         if (errors[0] || errors[1]) {
             return errors[0] && errors[1] ? Promise.reject(errors[0].concat(errors[1])) : errors[0] ? Promise.reject(errors[0]) : Promise.reject(errors[1]);

--- a/test/openapi3/openapi3-test.js
+++ b/test/openapi3/openapi3-test.js
@@ -102,6 +102,22 @@ describe('input-validation middleware tests', function () {
                     done();
                 });
         });
+        it('resolves content type for content-type with charset', function (done) {
+            request(app)
+                .post('/pet')
+                .set('public-key', '1.0')
+                .set('content-type', 'application/x-www-form-urlencoded; charset=utf-8')
+                .send({
+                    bark: 'foo'
+                })
+                .expect(200, function (err, res) {
+                    if (err) {
+                        throw err;
+                    }
+                    expect(res.body.result).to.equal('OK');
+                    done();
+                });
+        });
         it('valid cat', function (done) {
             request(app)
                 .post('/pet')


### PR DESCRIPTION
Should fix #106 

Updated request validation content-type to strip additional info. Similar approach as in https://github.com/Zooz/api-schema-builder/pull/29/files.